### PR TITLE
fix(prefix): Trim spaces after prefix

### DIFF
--- a/src/services/Commands.ts
+++ b/src/services/Commands.ts
@@ -110,7 +110,7 @@ export class Commands {
 
 		// Process prefix first so we can use any possible prefixes
 		if (content.startsWith(sets.prefix)) {
-			content = content.substring(sets.prefix.length);
+			content = content.substring(sets.prefix.length).trim();
 		} else if (idRegex.test(content)) {
 			const matches = content.match(idRegex);
 


### PR DESCRIPTION
If a user set the prefix to the mention of the bot, it would no longer respond to a message with the prefix followed by a space, then followed by the command. This also allows for command syntax such as `! ping`, which may be easier for mobile users.