### PR TITLE
feat(invites): Use cache for guild vanity URL

### DIFF
--- a/src/invites/commands/invites/inviteCodes.ts
+++ b/src/invites/commands/invites/inviteCodes.ts
@@ -54,7 +54,7 @@ export default class extends Command {
 				isWidget: !code.inviter
 			}));
 
-			const vanityInv = await guild.getVanity().catch(() => undefined);
+			const vanityInv = guild.vanityURL || (await guild.getVanity().catch(() => undefined));
 			if (vanityInv && vanityInv.code) {
 				newDbCodes.push({
 					code: vanityInv.code,

--- a/src/invites/services/Tracking.ts
+++ b/src/invites/services/Tracking.ts
@@ -312,7 +312,7 @@ export class TrackingService {
 
 		let isVanity = false;
 		if (inviteCodesUsed.length === 0) {
-			const vanityInv = await guild.getVanity().catch(() => undefined);
+			const vanityInv = guild.vanityURL || (await guild.getVanity().catch(() => undefined));
 			if (vanityInv && vanityInv.code) {
 				isVanity = true;
 				inviteCodesUsed.push(vanityInv.code as string);
@@ -749,7 +749,7 @@ export class TrackingService {
 		// Collect concurrent promises
 		const promises: any[] = [];
 
-		const vanityInv = await guild.getVanity().catch(() => undefined);
+		const vanityInv = guild.vanityURL || (await guild.getVanity().catch(() => undefined));
 		if (vanityInv && vanityInv.code) {
 			newInviteCodes.push({
 				code: vanityInv.code,


### PR DESCRIPTION
If available, use the cache for vanity URL instead of making a new request.