### PR TITLE
Make sure the bot auto restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: Dockerfile
     environment:
       WAIT_HOSTS: db:3306, rabbitmq:5672
+    restart: unless-stopped
     volumes:
       - .:/home/node/app
       - node_modules:/home/node/app/node_modules


### PR DESCRIPTION
Whenever you flush or change your firewall, it drops iptables for docker annoyingly, or if you are using a service that affect the iptables in general can make docker unusable.
When you restart docker, the restart command i added will make sure to restart the bot aswell. Without it, the bot will have to be manually started with 
docker-compose up -d