### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/check-i18n.js
+++ b/scripts/check-i18n.js
@@ -74,7 +74,7 @@ for (const [file, matches] of found) {
 	for (const match of matches) {
 		let variableIndex = match.indexOf('$');
 		if (variableIndex >= 0) {
-			variablePrefixes.push(match.substr(0, variableIndex));
+			variablePrefixes.push(match.slice(0, variableIndex));
 			console.log(chalk.yellow(`⚠️ ${chalk.blue(file)}: Variable found in ${chalk.blue(match)} - skipping checks`));
 			continue;
 		}

--- a/src/client.ts
+++ b/src/client.ts
@@ -558,11 +558,11 @@ export class IMClient extends Client {
 		if (logChannelId) {
 			const logChannel = guild.channels.get(logChannelId) as TextChannel;
 			if (logChannel) {
-				const content = message.content.substr(0, 1000) + (message.content.length > 1000 ? '...' : '');
+				const content = message.content.slice(0, 1000) + (message.content.length > 1000 ? '...' : '');
 
 				let json = JSON.stringify(data, null, 2);
 				if (json.length > 1000) {
-					json = json.substr(0, 1000) + '...';
+					json = json.slice(0, 1000) + '...';
 				}
 
 				const embed = this.msg.createEmbed({

--- a/src/framework/commands/Command.ts
+++ b/src/framework/commands/Command.ts
@@ -145,7 +145,7 @@ export abstract class Command {
 			const flag = this.flags[i];
 			const help = this.flagResolvers.get(flag.name).getHelp(context);
 			const descr = context.t(`cmd.${this.name}.self.flags.${flag.name}`);
-			info += `**--${flag.name}**\n${descr}\n` + (help ? `${help.substr(0, 800)}\n\n` : '\n');
+			info += `**--${flag.name}**\n${descr}\n` + (help ? `${help.slice(0, 800)}\n\n` : '\n');
 		}
 		for (let i = 0; i < this.args.length; i++) {
 			const arg = this.args[i];

--- a/src/framework/commands/info/help.ts
+++ b/src/framework/commands/info/help.ts
@@ -33,7 +33,7 @@ export default class extends Command {
 			const cmd = {
 				...command,
 				usage: command.usage.replace('{prefix}', prefix),
-				info: command.getInfo(context).substr(0, 900)
+				info: command.getInfo(context).slice(0, 900)
 			};
 
 			embed.fields.push({

--- a/src/framework/services/Messaging.ts
+++ b/src/framework/services/Messaging.ts
@@ -50,7 +50,7 @@ export class MessagingService extends IMService {
 		let color = options.color ? (options.color as number | string) : parseInt('00AE86', 16);
 		// Parse colors in hashtag/hex format
 		if (typeof color === 'string') {
-			const code = color.startsWith('#') ? color.substr(1) : color;
+			const code = color.startsWith('#') ? color.slice(1) : color;
 			color = parseInt(code, 16);
 		}
 

--- a/src/invites/commands/invites/info.ts
+++ b/src/invites/commands/invites/info.ts
@@ -360,7 +360,7 @@ export default class extends Command {
 			let text = customInvText + more + detailMsg;
 			const diff = text.length - 1024;
 			if (diff > 0) {
-				text = customInvText.substr(0, customInvText.length - diff - 3) + '...' + more;
+				text = customInvText.slice(0, -diff - 3) + '...' + more;
 			}
 
 			embed.fields.push({

--- a/src/invites/services/Captcha.ts
+++ b/src/invites/services/Captcha.ts
@@ -111,7 +111,7 @@ export class CaptchaService extends IMService {
 		config.background = config.background || 'rgb(255,255,255)';
 		config.lineWidth = config.lineWidth || 2;
 		config.saveDir = config.saveDir || __dirname;
-		config.text = config.text || Math.random().toString().substr(2, config.size);
+		config.text = config.text || Math.random().toString().slice(2, 2 + config.size);
 		config.noise = config.noise !== false ? true : false;
 		config.noiseColor = config.noiseColor || config.color;
 		config.complexity = config.complexity || 3;

--- a/src/moderation/commands/info/check.ts
+++ b/src/moderation/commands/info/check.ts
@@ -66,7 +66,7 @@ export default class extends Command {
 		if (strikeText) {
 			embed.fields.push({
 				name: t('cmd.check.strikes.title'),
-				value: strikeText.substr(0, 1020)
+				value: strikeText.slice(0, 1020)
 			});
 		}
 
@@ -84,7 +84,7 @@ export default class extends Command {
 		if (punishmentText) {
 			embed.fields.push({
 				name: t('cmd.check.punishments.title'),
-				value: punishmentText.substr(0, 1020)
+				value: punishmentText.slice(0, 1020)
 			});
 		}
 

--- a/src/moderation/commands/mod/unhoist.ts
+++ b/src/moderation/commands/mod/unhoist.ts
@@ -90,7 +90,7 @@ export default class extends Command {
 					continue;
 				}
 
-				const newName = (NAME_DEHOIST_PREFIX + ' ' + name).substr(0, 32);
+				const newName = (NAME_DEHOIST_PREFIX + ' ' + name).slice(0, 32);
 				await guild
 					.editMember(member.user.id, { nick: newName }, 'Unhoist command')
 					.then(() => changed++)

--- a/src/moderation/services/Moderation.ts
+++ b/src/moderation/services/Moderation.ts
@@ -286,7 +286,7 @@ export class ModerationService extends IMService {
 		if (extra) {
 			extra
 				.filter((e) => !!e.value)
-				.forEach((e) => logEmbed.fields.push({ name: e.name, value: e.value.substr(0, 1024) }));
+				.forEach((e) => logEmbed.fields.push({ name: e.name, value: e.value.slice(0, 1024) }));
 		}
 		await this.client.logModAction(guild, logEmbed);
 	}
@@ -585,7 +585,7 @@ export class ModerationService extends IMService {
 		const strike = strikesCache.find((s) => s.type === type);
 		const amount = strike ? strike.amount : 0;
 
-		const newName = (NAME_DEHOIST_PREFIX + ' ' + name).substr(0, 32);
+		const newName = (NAME_DEHOIST_PREFIX + ' ' + name).slice(0, 32);
 		member.edit({ nick: newName }, 'Auto dehoist').catch(() => undefined);
 
 		await this.logViolationModAction(guild, member.user, type, amount, [

--- a/src/music/models/ravedj/RaveDJ.ts
+++ b/src/music/models/ravedj/RaveDJ.ts
@@ -49,7 +49,7 @@ export class RaveDJ extends MusicPlatform {
 	}
 
 	public async getByLink(link: string): Promise<MusicItem> {
-		const id = link.substr(link.indexOf('.dj/') + 4);
+		const id = link.slice(link.indexOf('.dj/') + 4);
 
 		const url = `https://api.red.wemesh.ca/ravedj/${id}`;
 		const opts = {

--- a/src/music/services/MusicService.ts
+++ b/src/music/services/MusicService.ts
@@ -126,7 +126,7 @@ export class MusicService extends IMService {
 	private decodeHTMLEntities(str: string) {
 		return str.replace(/&#?[0-9a-zA-Z]+;?/g, (s) => {
 			if (s.charAt(1) === '#') {
-				const code = s.charAt(2).toLowerCase() === 'x' ? parseInt(s.substr(3), 16) : parseInt(s.substr(2), 10);
+				const code = s.charAt(2).toLowerCase() === 'x' ? parseInt(s.slice(3), 16) : parseInt(s.slice(2), 10);
 
 				if (isNaN(code) || code < -32768 || code > 65535) {
 					return '';

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -770,7 +770,7 @@ export function beautify(type: InternalSettingsTypes, value: any) {
 
 		default:
 			if (typeof value === 'string' && value.length > 1000) {
-				return '`' + value.substr(0, 1000) + '`...';
+				return '`' + value.slice(0, 1000) + '`...';
 			}
 			return `\`${value}\``;
 	}


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.